### PR TITLE
fix: use exporter with types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,17 +19,17 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.2.tgz",
-      "integrity": "sha512-OgC1mON+l4U4B4wiohJlQNUU3H73mpTyYY3j/c8U9dr9UagGGSm+WFpzjy/YLdoyjiG++c1kIDgxCo/mLwQJeQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+      "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.2",
+        "@babel/generator": "^7.14.3",
         "@babel/helper-compilation-targets": "^7.13.16",
         "@babel/helper-module-transforms": "^7.14.2",
         "@babel/helpers": "^7.14.0",
-        "@babel/parser": "^7.14.2",
+        "@babel/parser": "^7.14.3",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.14.2",
         "@babel/types": "^7.14.2",
@@ -50,9 +50,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.2.tgz",
-      "integrity": "sha512-OnADYbKrffDVai5qcpkMxQ7caomHOoEwjkouqnN2QhydAjowFAZcsdecFIRUBdb+ZcruwYE4ythYmF1UBZU5xQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.14.2",
@@ -144,15 +144,15 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+      "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
       }
     },
     "@babel/helper-simple-access": {
@@ -206,9 +206,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.2.tgz",
-      "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+      "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
       "dev": true
     },
     "@babel/template": {
@@ -407,9 +407,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
-      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ=="
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -877,9 +877,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.727",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "version": "1.3.731",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.731.tgz",
+      "integrity": "sha512-dn1Nyd0DuFa3xhqZJr6/L9phyk+YXJpvrz6Vcu6mFxFqr5TQ9r/F3yvOYFUrEwY4Tbb1YBjN19TDKnSVCQvalA==",
       "dev": true
     },
     "emoji-regex": {
@@ -1169,8 +1169,8 @@
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb",
-      "integrity": "sha512-2sEsgyoOQGOvscxVN/Fm7cdcsU6C2lMeB0c+Hj4o04U7pwL7opfYr6anf7ahE7D3gPj1INvjd0ne4SDYDwFGHQ==",
+      "version": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb-with-dist",
+      "integrity": "sha512-x2DfNlNV+PrCPRgf8ZoozZCz0Crg2dyQQOsaJ8YbCkuvVN2Y27/alX+y0s+NJ+SxP6At+1v6qmmeDW76+MpkjQ==",
       "requires": {
         "@ipld/dag-cbor": "^5.0.0",
         "@ipld/dag-pb": "^1.1.0",
@@ -1730,9 +1730,9 @@
       }
     },
     "multiformats": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.5.tgz",
-      "integrity": "sha512-kwKJdlcE7Vb54FI4Xtw5zrB1pb530tOMCSQ2iMOzGAkOqM5n5vkgi57LZhC2q1ywhEnhXl9T94NEhwqE/SdVmw=="
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
+      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
     },
     "multihashes": {
       "version": "4.0.2",
@@ -2350,9 +2350,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
+      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@ipld/car": "^1.0.5",
     "@types/bl": "^5.0.1",
     "bl": "^5.0.0",
-    "ipfs-unixfs-exporter": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb",
+    "ipfs-unixfs-exporter": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb-with-dist",
     "it-pipe": "^1.1.0",
     "meow": "^9.0.0",
     "multiformats": "^8.0.4",


### PR DESCRIPTION
Updates exporter to a new branch with a commit that adds the dist folder to have the types (the dist folder is created in the release). There were type failures before, but it was due to the exporter to depend on the importer old version, which had the old CID. So, I linked also there the new one.

This also removed the `CarReaderish` type definition in favour of simply accepting `CarReader|CarIndexedReader` in `fromCar`