### PR TITLE
fix: show the full filename in output for --pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ or unpack files from a .car, and verify that every block matches it's CID
 $ ipfs-car --unpack my-files.car --output path/to/write/to
 ```
 
+Fetch and locally verify files from a IPFS gateway over http
+
+```sh
+curl -X POST "https://ipfs.io/api/v0/dag/export?arg=bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu" | 🚘
+```
+
 ## Install
 
 ```sh

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -100,7 +100,7 @@ async function handleInput ({ flags }: { flags: Flags }) {
     // tslint:disable-next-line: no-console
     console.log(`root CID: ${root.toString()}`)
     // tslint:disable-next-line: no-console
-    console.log(`  output: ${filename}`)   
+    console.log(`  output: ${filename}`)
   } else if (flags.unpack !== undefined) {
     const roots = (flags.root || []).map(r => CID.parse(r))
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -100,7 +100,7 @@ async function handleInput ({ flags }: { flags: Flags }) {
     // tslint:disable-next-line: no-console
     console.log(`root CID: ${root.toString()}`)
     // tslint:disable-next-line: no-console
-    console.log(`output: ${filename}`)
+    console.log(`  output: ${filename}`)   
   } else if (flags.unpack !== undefined) {
     const roots = (flags.root || []).map(r => CID.parse(r))
 

--- a/src/pack/fs.ts
+++ b/src/pack/fs.ts
@@ -21,8 +21,9 @@ export async function packToFs ({ input, output, blockstore: userBlockstore }: {
 
   // Move to work dir
   if (!output) {
-    const filename = typeof input === 'string' ? path.parse(path.basename(input)).name : root.toString()
-    await moveFile(location, `${process.cwd()}/${filename}.car`)
+    const basename = typeof input === 'string' ? path.parse(path.basename(input)).name : root.toString()
+    const filename = `${basename}.car`
+    await moveFile(location, `${process.cwd()}/${filename}`)
 
     return {root, filename}
   }


### PR DESCRIPTION
- show the .car extention in the output
- line up the output
- add a note to the README about curling CARs from the gateway

```console
ipfs-car --pack ~/Downloads/GMT20210520-203336_Recording_1920x1576.mp4
root CID: bafybeiefsr3v4tbbudkwr6uooeld2bp4cbkpsbgyiyqj6uiu3j2pau4ogy
  output: GMT20210520-203336_Recording_1920x1576.car
```
License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>