### PR TITLE
fix: add package json to esm build to hint module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run compile:esm && npm run compile:cjs",
-    "compile:esm": "tsc -p tsconfig.json",
+    "compile:esm": "tsc -p tsconfig.json && echo '{ \"type\" : \"module\" }' > dist/esm/package.json",
     "compile:cjs": "tsc -p tsconfig-cjs.json",
     "lint": "tslint 'src/**/*.ts?(x)'",
     "test": "npm run test:node && npm run test:browser",


### PR DESCRIPTION
Trying this out in nft.storage Node.js example was also problematic. This is because Node thinks the esm folder is cjs. The two solutions were to rename the files to `*.mjs` or add a package.json with that. How typescript build does not handle this is strange, but their compile should not be thought for multiple compiles and not using the original `package.json`