### PR TITLE
fix: esm imports need js extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
-      "integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.19.tgz",
+      "integrity": "sha512-jRJgpRBuY+7izT7/WNXP/LsMO9YonsstuL+xuvycDyESpoDoIAsMd7suwpB4h9oEWB+ZlPTqJJ8EHomzNhwTPQ==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -3283,9 +3283,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.12.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.3.tgz",
-      "integrity": "sha512-SNt65CPCXvGNDZ3bvk1TQ0Qxoe3y1RKH88+wZ2Uf05dduBCqqFQ76ADP9pbT+Cpvj60SkRppMCh2Zo8tDixqjQ=="
+      "version": "15.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
+      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3374,7 +3374,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.0.tgz",
       "integrity": "sha512-6RlyqSbcSw3Uhkz9tmZdbBbSNLTFmb0/M5wqaxakqKcjLNXNZNX1cYJcszOzfQ2U6VM6hTlOlun/vGiJuVsUiQ==",
-      "license": "MIT",
       "dependencies": {
         "@ipld/dag-pb": "^2.0.2",
         "bl": "^5.0.0",
@@ -4221,9 +4220,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001238",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz",
-      "integrity": "sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw==",
+      "version": "1.0.30001239",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
+      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -4685,9 +4684,9 @@
       "peer": true
     },
     "node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
@@ -6460,9 +6459,9 @@
       }
     },
     "node_modules/ipfs-core-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.1.tgz",
-      "integrity": "sha512-HE5iE4j9Qa6c/4mfaD1cYYx8mbRRkrrcWekDG1JAP7mEK2wPnMvMemmFTgFF4KN6bW9gIusJjqPpCweesORPuA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.2.tgz",
+      "integrity": "sha512-DOQeL+GFGYMTlnbdtMeBzvfVnyAalSgCfPr8XUCI+FVBZZWwzkt5jZZzGDmF87HVRrMR3FuVyBKZj772mcXKyQ==",
       "dependencies": {
         "cids": "^1.1.6",
         "interface-datastore": "^4.0.0",
@@ -6472,16 +6471,16 @@
       }
     },
     "node_modules/ipfs-core-utils": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.2.tgz",
-      "integrity": "sha512-vz3BugR4ykoJzoWQPcAyGjoW8RfUNWDyjqd51GgfcYICTFATh4c2k8Md1aEGuKdOUJNvCpOL48j1lXv8KNIp7A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.3.tgz",
+      "integrity": "sha512-PY7PkCgCtVYtNOe1C3ew1+5D9NqXqizb886R/lyGWe+KsmWtBQkQIk0ZIDwKyHGvG2KA2QQeIDzdOmzBQBJtHQ==",
       "dependencies": {
         "any-signal": "^2.1.2",
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
         "cids": "^1.1.6",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.5.1",
+        "ipfs-core-types": "^0.5.2",
         "ipfs-unixfs": "^4.0.3",
         "ipfs-utils": "^8.1.2",
         "it-all": "^1.0.4",
@@ -6508,9 +6507,9 @@
       }
     },
     "node_modules/ipfs-utils": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.2.tgz",
-      "integrity": "sha512-ataZ23Q+awQ6s01ehpITzEgDZ8YgU17nWkwiQmmZeQAJsS6wZuKfGXJKzdOX00+wn5SWJ8KRpGOG/u9+a4Z8Jw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.3.tgz",
+      "integrity": "sha512-QS7P9cL7rXah8uB7Wv2fx4E/7/Yr72WxYNv5eIh9dUyxS6/JacgCaVYQgNn4uZ4ps/teYE1yESTUXMWmGa/DoQ==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "any-signal": "^2.1.0",
@@ -9199,9 +9198,9 @@
     },
     "node_modules/node-fetch": {
       "name": "@achingbrain/node-fetch",
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-cR5rkxDwvXO30y8SzOC/QV0ziKojMeiteeEiV09AxrlBCuI1d8xVNpsM2M5g9L5qbDF9629bkXm4NPSCy3RVfA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -15982,9 +15981,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
-      "integrity": "sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.19.tgz",
+      "integrity": "sha512-jRJgpRBuY+7izT7/WNXP/LsMO9YonsstuL+xuvycDyESpoDoIAsMd7suwpB4h9oEWB+ZlPTqJJ8EHomzNhwTPQ==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -16036,9 +16035,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.3.tgz",
-      "integrity": "sha512-SNt65CPCXvGNDZ3bvk1TQ0Qxoe3y1RKH88+wZ2Uf05dduBCqqFQ76ADP9pbT+Cpvj60SkRppMCh2Zo8tDixqjQ=="
+      "version": "15.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
+      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -16781,9 +16780,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001238",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001238.tgz",
-      "integrity": "sha512-bZGam2MxEt7YNsa2VwshqWQMwrYs5tR5WZQRYSuFxsBQunWjBuXhN4cS9nV5FFb1Z9y+DoQcQ0COyQbv6A+CKw=="
+      "version": "1.0.30001239",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
+      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -17156,9 +17155,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "requires": {
         "safe-buffer": "~5.1.1"
       },
@@ -18527,9 +18526,9 @@
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
     },
     "ipfs-core-types": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.1.tgz",
-      "integrity": "sha512-HE5iE4j9Qa6c/4mfaD1cYYx8mbRRkrrcWekDG1JAP7mEK2wPnMvMemmFTgFF4KN6bW9gIusJjqPpCweesORPuA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.2.tgz",
+      "integrity": "sha512-DOQeL+GFGYMTlnbdtMeBzvfVnyAalSgCfPr8XUCI+FVBZZWwzkt5jZZzGDmF87HVRrMR3FuVyBKZj772mcXKyQ==",
       "requires": {
         "cids": "^1.1.6",
         "interface-datastore": "^4.0.0",
@@ -18539,16 +18538,16 @@
       }
     },
     "ipfs-core-utils": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.2.tgz",
-      "integrity": "sha512-vz3BugR4ykoJzoWQPcAyGjoW8RfUNWDyjqd51GgfcYICTFATh4c2k8Md1aEGuKdOUJNvCpOL48j1lXv8KNIp7A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.3.tgz",
+      "integrity": "sha512-PY7PkCgCtVYtNOe1C3ew1+5D9NqXqizb886R/lyGWe+KsmWtBQkQIk0ZIDwKyHGvG2KA2QQeIDzdOmzBQBJtHQ==",
       "requires": {
         "any-signal": "^2.1.2",
         "blob-to-it": "^1.0.1",
         "browser-readablestream-to-it": "^1.0.1",
         "cids": "^1.1.6",
         "err-code": "^3.0.1",
-        "ipfs-core-types": "^0.5.1",
+        "ipfs-core-types": "^0.5.2",
         "ipfs-unixfs": "^4.0.3",
         "ipfs-utils": "^8.1.2",
         "it-all": "^1.0.4",
@@ -18571,9 +18570,9 @@
       }
     },
     "ipfs-utils": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.2.tgz",
-      "integrity": "sha512-ataZ23Q+awQ6s01ehpITzEgDZ8YgU17nWkwiQmmZeQAJsS6wZuKfGXJKzdOX00+wn5SWJ8KRpGOG/u9+a4Z8Jw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.3.tgz",
+      "integrity": "sha512-QS7P9cL7rXah8uB7Wv2fx4E/7/Yr72WxYNv5eIh9dUyxS6/JacgCaVYQgNn4uZ4ps/teYE1yESTUXMWmGa/DoQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^2.1.0",
@@ -20725,9 +20724,9 @@
       }
     },
     "node-fetch": {
-      "version": "npm:@achingbrain/node-fetch@2.6.6",
-      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-cR5rkxDwvXO30y8SzOC/QV0ziKojMeiteeEiV09AxrlBCuI1d8xVNpsM2M5g9L5qbDF9629bkXm4NPSCy3RVfA=="
+      "version": "npm:@achingbrain/node-fetch@2.6.7",
+      "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@types/chai": "^4.2.18",
         "@types/mocha": "^8.2.2",
         "@types/sinon": "^10.0.2",
+        "@zoltu/typescript-transformer-append-js-extension": "^1.0.1",
         "assert": "^2.0.0",
         "chai": "^4.3.4",
         "mocha": "^8.4.0",
@@ -43,6 +44,7 @@
         "sinon": "^11.1.1",
         "ts-node": "^9.1.1",
         "tslint": "^6.1.3",
+        "ttypescript": "^1.5.12",
         "typescript": "^4.2.4",
         "util": "^0.12.4"
       }
@@ -3403,6 +3405,12 @@
         "web-encoding": "1.1.5",
         "web-streams-polyfill": "3.0.3"
       }
+    },
+    "node_modules/@zoltu/typescript-transformer-append-js-extension": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@zoltu/typescript-transformer-append-js-extension/-/typescript-transformer-append-js-extension-1.0.1.tgz",
+      "integrity": "sha512-7Lp30MtJO7YHZW19yJWhkuJrf+Y78COHopeZli7fiWrbIRvodsSXZIa7cFX/c4PFwFJt55N/7Pp/t6VH0fwBVQ==",
+      "dev": true
     },
     "node_modules/@zxing/text-encoding": {
       "version": "0.9.0",
@@ -12813,6 +12821,23 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/ttypescript": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+      "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+      "dev": true,
+      "dependencies": {
+        "resolve": ">=1.9.0"
+      },
+      "bin": {
+        "ttsc": "bin/tsc",
+        "ttsserver": "bin/tsserver"
+      },
+      "peerDependencies": {
+        "ts-node": ">=8.0.2",
+        "typescript": ">=3.2.2"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -16124,6 +16149,12 @@
         "web-encoding": "1.1.5",
         "web-streams-polyfill": "3.0.3"
       }
+    },
+    "@zoltu/typescript-transformer-append-js-extension": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@zoltu/typescript-transformer-append-js-extension/-/typescript-transformer-append-js-extension-1.0.1.tgz",
+      "integrity": "sha512-7Lp30MtJO7YHZW19yJWhkuJrf+Y78COHopeZli7fiWrbIRvodsSXZIa7cFX/c4PFwFJt55N/7Pp/t6VH0fwBVQ==",
+      "dev": true
     },
     "@zxing/text-encoding": {
       "version": "0.9.0",
@@ -23545,6 +23576,15 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "ttypescript": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+      "integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+      "dev": true,
+      "requires": {
+        "resolve": ">=1.9.0"
       }
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prepare": "npm run build",
     "build": "npm run compile:esm && npm run compile:cjs",
-    "compile:esm": "tsc -p tsconfig.json && echo '{ \"type\" : \"module\" }' > dist/esm/package.json",
+    "compile:esm": "ttsc -p tsconfig.json && echo '{ \"type\" : \"module\" }' > dist/esm/package.json",
     "compile:cjs": "tsc -p tsconfig-cjs.json",
     "lint": "tslint 'src/**/*.ts?(x)'",
     "test": "npm run test:node && npm run test:browser",
@@ -139,6 +139,7 @@
     "@types/chai": "^4.2.18",
     "@types/mocha": "^8.2.2",
     "@types/sinon": "^10.0.2",
+    "@zoltu/typescript-transformer-append-js-extension": "^1.0.1",
     "assert": "^2.0.0",
     "chai": "^4.3.4",
     "mocha": "^8.4.0",
@@ -147,6 +148,7 @@
     "sinon": "^11.1.1",
     "ts-node": "^9.1.1",
     "tslint": "^6.1.3",
+    "ttypescript": "^1.5.12",
     "typescript": "^4.2.4",
     "util": "^0.12.4"
   }

--- a/src/blockstore/fs.ts
+++ b/src/blockstore/fs.ts
@@ -4,7 +4,7 @@ import os from 'os'
 import { CID } from 'multiformats'
 import { Block } from '@ipld/car/api'
 
-import { Blockstore } from './'
+import { Blockstore } from './index'
 
 export class FsBlockStore implements Blockstore {
   path: string

--- a/src/blockstore/memory.ts
+++ b/src/blockstore/memory.ts
@@ -1,7 +1,7 @@
 import { CID } from 'multiformats'
 import { Block } from '@ipld/car/api'
 
-import { Blockstore } from './'
+import { Blockstore } from './index'
 
 export class MemoryBlockStore implements Blockstore {
   store: Map<string, Uint8Array>

--- a/src/pack/blob.ts
+++ b/src/pack/blob.ts
@@ -5,7 +5,7 @@ import { ImportCandidateStream } from 'ipfs-core-types/src/utils'
 import { Blockstore } from '../blockstore'
 import { MemoryBlockStore } from '../blockstore/memory'
 
-import { pack } from './'
+import { pack } from './index'
 
 export async function packToBlob ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/pack/fs.ts
+++ b/src/pack/fs.ts
@@ -5,7 +5,7 @@ import moveFile from 'move-file'
 
 import { packToStream } from './stream'
 
-import { Blockstore } from '../blockstore'
+import { Blockstore } from '../blockstore/index'
 import { FsBlockStore } from '../blockstore/fs'
 
 export async function packToFs ({ input, output, blockstore: userBlockstore }: { input: string | Iterable<string> | AsyncIterable<string>, output?: string, blockstore?: Blockstore }) {

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -7,7 +7,7 @@ import normalizeAddInput from 'ipfs-core-utils/src/files/normalise-input/index'
 import { ImportCandidateStream } from 'ipfs-core-types/src/utils'
 import { sha256 } from 'multiformats/hashes/sha2'
 
-import { Blockstore } from '../blockstore'
+import { Blockstore } from '../blockstore/index'
 import { MemoryBlockStore } from '../blockstore/memory'
 
 export async function pack ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -3,7 +3,7 @@ import pipe from 'it-pipe'
 
 import { CarWriter } from '@ipld/car'
 import { importer } from '@vascosantos/ipfs-unixfs-importer'
-import normalizeAddInput from 'ipfs-core-utils/src/files/normalise-input/index'
+import normalizeAddInput from 'ipfs-core-utils/src/files/normalise-input/index.js'
 import { ImportCandidateStream } from 'ipfs-core-types/src/utils'
 import { sha256 } from 'multiformats/hashes/sha2'
 

--- a/src/pack/stream.ts
+++ b/src/pack/stream.ts
@@ -9,7 +9,7 @@ import normalizeAddInput from 'ipfs-core-utils/src/files/normalise-input/index'
 import globSource from 'ipfs-utils/src/files/glob-source'
 import { sha256 } from 'multiformats/hashes/sha2'
 
-import { Blockstore } from '../blockstore'
+import { Blockstore } from '../blockstore/index'
 import { MemoryBlockStore } from '../blockstore/memory'
 
 // Node version of toCar with Node Stream Writable

--- a/src/unpack/fs.ts
+++ b/src/unpack/fs.ts
@@ -10,7 +10,7 @@ import { UnixFSEntry } from '@vascosantos/ipfs-unixfs-exporter'
 // tslint:disable-next-line: no-var-requires needs types
 const toIterable = require('stream-to-it')
 
-import { unpack } from '.'
+import { unpack } from './index'
 
 // Node only, read a car from fs, write files to fs
 export async function unpackToFs ({input, roots, output}: {input: string, roots?: CID[], output?: string}) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,7 +67,13 @@
 
     /* Advanced Options */
     "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true,        /* Disallow inconsistently-cased references to the same file. */
+    "plugins": [
+      {
+        "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js",
+        "after": true,
+      }
+    ]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Because [nodejs requires file extensions for relative imports](https://nodejs.org/api/esm.html#esm_mandatory_file_extensions), the current esm build fails to use in Node.js

As an example, importing `packToBlob`:

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/Users/vsantos/work/pl/gh/protocol/nft.storage/packages/client/examples/node.js/node_modules/ipfs-car/dist/esm/pack/' is not supported resolving ES modules imported from /Users/vsantos/work/pl/gh/protocol/nft.storage/packages/client/examples/node.js/node_modules/ipfs-car/dist/esm/pack/blob.js
```

This PR uses [ttsc](https://github.com/cevek/ttypescript) to rely on a custom transformer, which during the build adds the `.js` extension to relative imports. Note that `index.js` is not inferred and `index` needed to be added

Related:

- https://github.com/microsoft/TypeScript/issues/42813
- https://github.com/microsoft/TypeScript/issues/16577
- https://github.com/nodejs/modules/issues/444
