### PR TITLE
chore: export external types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
-      "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-      "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
       "dependencies": {
         "@babel/types": "^7.14.5"
       },
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
-      "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+      "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.5.tgz",
-      "integrity": "sha512-tbD/CG3l43FIXxmu4a7RBe4zH7MLJ+S/lFowPFO7HetS2hyOZ/0nnnznegDuzFzfkyQYTxqdTH/hKmuBngaDAA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.7.tgz",
+      "integrity": "sha512-RK8Wj7lXLY3bqei69/cc25gwS5puEc3dknoFPFbqfy3XxYQBQFvu4ioWpafMBAB+L9NyptQK4nMOa5Xz16og8Q==",
       "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -727,12 +727,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.5.tgz",
-      "integrity": "sha512-VzMyY6PWNPPT3pxc5hi9LloKNr4SSrVCg7Yr6aZpW4Ym07r7KqSU/QXYwjXLVxqwSv0t/XSXkFoKBPUkZ8vb2A==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+      "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.14.7",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
@@ -1164,9 +1164,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.5.tgz",
-      "integrity": "sha512-wU9tYisEbRMxqDezKUqC9GleLycCRoUsai9ddlsq54r8QRLaeEhc+d+9DqCG+kV9W2GgQjTZESPTpn5bAFMDww==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
       "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.5.tgz",
-      "integrity": "sha512-+Xe5+6MWFo311U8SchgeX5c1+lJM+eZDBZgD+tvXu9VVQPXwwVzeManMMjYX6xw2HczngfOSZjoFYKwdeB/Jvw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.7.tgz",
+      "integrity": "sha512-DTNOTaS7TkW97xsDMrp7nycUVh6sn/eq22VaxWfEdzuEbRsiaOU0pqU7DlyUGHVsbQbSghvjKRpEl+nUCKGQSg==",
       "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.14.5"
@@ -1711,17 +1711,17 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.5.tgz",
-      "integrity": "sha512-ci6TsS0bjrdPpWGnQ+m4f+JSSzDKlckqKIJJt9UZ/+g7Zz9k0N8lYU8IeLg/01o2h8LyNZDMLGgRLDTxpudLsA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.7.tgz",
+      "integrity": "sha512-itOGqCKLsSUl0Y+1nSfhbuuOlTs0MJk2Iv7iSH+XT/mR8U1zRLO7NjWlYXB47yhK4J/7j+HYty/EhFZDYKa/VA==",
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.14.7",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-        "@babel/plugin-proposal-async-generator-functions": "^7.14.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.14.7",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-class-static-block": "^7.14.5",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -1730,7 +1730,7 @@
         "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
         "@babel/plugin-proposal-optional-chaining": "^7.14.5",
         "@babel/plugin-proposal-private-methods": "^7.14.5",
@@ -1756,7 +1756,7 @@
         "@babel/plugin-transform-block-scoping": "^7.14.5",
         "@babel/plugin-transform-classes": "^7.14.5",
         "@babel/plugin-transform-computed-properties": "^7.14.5",
-        "@babel/plugin-transform-destructuring": "^7.14.5",
+        "@babel/plugin-transform-destructuring": "^7.14.7",
         "@babel/plugin-transform-dotall-regex": "^7.14.5",
         "@babel/plugin-transform-duplicate-keys": "^7.14.5",
         "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
@@ -1768,7 +1768,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.14.5",
         "@babel/plugin-transform-modules-systemjs": "^7.14.5",
         "@babel/plugin-transform-modules-umd": "^7.14.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.5",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.7",
         "@babel/plugin-transform-new-target": "^7.14.5",
         "@babel/plugin-transform-object-super": "^7.14.5",
         "@babel/plugin-transform-parameters": "^7.14.5",
@@ -1776,7 +1776,7 @@
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
         "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.5",
+        "@babel/plugin-transform-spread": "^7.14.6",
         "@babel/plugin-transform-sticky-regex": "^7.14.5",
         "@babel/plugin-transform-template-literals": "^7.14.5",
         "@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -1787,7 +1787,7 @@
         "babel-plugin-polyfill-corejs2": "^0.2.2",
         "babel-plugin-polyfill-corejs3": "^0.2.2",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
-        "core-js-compat": "^3.14.0",
+        "core-js-compat": "^3.15.0",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -2010,16 +2010,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-      "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
       "dependencies": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.5",
+        "@babel/parser": "^7.14.7",
         "@babel/types": "^7.14.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -2063,18 +2063,18 @@
       "peer": true
     },
     "node_modules/@hapi/topo": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "peer": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@ipld/car": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.0.3.tgz",
-      "integrity": "sha512-c5/LmjjWFDicqcRvJNfhC394wt9ZUKDzzdzMZdrXI1xCBCCtimlKhVaIlxh2+9lFvV50alPBqGK+jhnjXPbmEQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.2.tgz",
+      "integrity": "sha512-BW1W9S7ol4I0OXx604XjvUABj9RLiNetOiJ3drdbGMvh6YgzCTnBDHPjvilB5tMs1yml2we2T6YHtgJvXg5osA==",
       "dependencies": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.0.2.tgz",
-      "integrity": "sha512-m0XOtq2zx+F6FqPCrBh4tjTxyAzRE8IIjAPZsfXoXcqOC8HhOiH3nrvk3sXgLuU3Ttxkitkn5ntS4r8LX0ZDVA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.1.tgz",
+      "integrity": "sha512-bB7HxHlyKtLRbZVJQxdi+CakXFfQKogINzUxvhfGURUpZLvwTq3x8jwHT1UvPWuO0SHgMBQN5mIBeOUnes3MHg==",
       "dependencies": {
         "multiformats": "^9.0.0"
       }
@@ -2458,29 +2458,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "peer": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/@react-native-community/cli-platform-android/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2491,15 +2468,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-platform-android/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
@@ -2883,29 +2851,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/@react-native-community/cli/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "peer": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/@react-native-community/cli/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3135,15 +3080,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@react-native-community/cli/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "peer": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/@react-native/assets": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz",
@@ -3271,6 +3207,11 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -3283,9 +3224,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -3371,11 +3312,11 @@
       }
     },
     "node_modules/@vascosantos/ipfs-unixfs-importer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.0.tgz",
-      "integrity": "sha512-6RlyqSbcSw3Uhkz9tmZdbBbSNLTFmb0/M5wqaxakqKcjLNXNZNX1cYJcszOzfQ2U6VM6hTlOlun/vGiJuVsUiQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.3.tgz",
+      "integrity": "sha512-kVcp+yZavn5Tn5EL7RHH51kSoO+gx1Yz22NtzmPFVNRx/cZ039VNZFI5XHkFT4FkFiskLv97nEzM/rOyug0wRw==",
       "dependencies": {
-        "@ipld/dag-pb": "^2.0.2",
+        "@ipld/dag-pb": "^2.1.1",
         "bl": "^5.0.0",
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
@@ -3385,11 +3326,11 @@
         "it-first": "^1.0.6",
         "it-parallel-batch": "^1.0.9",
         "merge-options": "^3.0.4",
-        "multicodec": "^3.0.1",
+        "multicodec": "^3.1.0",
         "multiformats": "^9.0.4",
         "multihashing-async": "^2.1.0",
         "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.2"
+        "uint8arrays": "^2.1.5"
       },
       "engines": {
         "node": ">=14.0.0",
@@ -3563,9 +3504,9 @@
       }
     },
     "node_modules/appdirsjs": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.4.tgz",
-      "integrity": "sha512-WO5StDORR6JF/xYnXk/Fm0yu+iULaV5ULKuUw0Tu+jbgiTlSquaWBCgbpnsHLMXldf+fM3Gxn5p7vjond7He6w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.5.tgz",
+      "integrity": "sha512-UyaAyzj+7XLoKhbXJi4zoAw8IDXCiLNCKfQEiuCsCCTkDmiG1vpCliQn/MoUvO3DZqCN1i6gOahokcFtNSIrVA==",
       "peer": true
     },
     "node_modules/append-transform": {
@@ -3740,14 +3681,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "peer": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -3965,9 +3898,9 @@
       }
     },
     "node_modules/blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
+      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "node_modules/blob-to-it": {
       "version": "1.0.2",
@@ -4220,9 +4153,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001239",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
@@ -4706,9 +4639,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.0.tgz",
-      "integrity": "sha512-8X6lWsG+s7IfOKzV93a7fRYfWRZobOfjw5V5rrq43Vh/W+V6qYxl7Akalsvgab4PFT/4L/pjQbdBUEM36NXKrw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.1.tgz",
+      "integrity": "sha512-xGhzYMX6y7oEGQGAJmP2TmtBLvR4nZmRGEcFa3ubHOq5YEp51gGN9AovVa0AoujGZIq+Wm6dISiYyGNfdflYww==",
       "peer": true,
       "dependencies": {
         "browserslist": "^4.16.6",
@@ -5086,9 +5019,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.752",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A=="
+      "version": "1.3.760",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.760.tgz",
+      "integrity": "sha512-XPKwjX6pHezJWB4FLVuSil9gGmU6XYl27ahUwEHODXF4KjCEB8RuIT05MkU1au2Tdye57o49yY0uCMK+bwUt+A=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5671,17 +5604,16 @@
       "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       },
       "engines": {
         "node": ">=8"
@@ -5887,17 +5819,17 @@
       ]
     },
     "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "peer": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -7182,11 +7114,11 @@
       "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
     },
     "node_modules/it-glob": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.11.tgz",
-      "integrity": "sha512-p02iVYsvOPU7cW4sV9BC62Kz6Mz2aUTJz/cKWDeFqc05kzB3WgSq8OobZabVA/K4boSm6q+s0xOZ8xiArLSoXQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
+      "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
       "dependencies": {
-        "fs-extra": "^9.0.1",
+        "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
       }
     },
@@ -7635,12 +7567,10 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -8996,9 +8926,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multiaddr": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.1.tgz",
-      "integrity": "sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.2.tgz",
+      "integrity": "sha512-YFaEb9t4yXSbaGksSEdg+Kn2U02s7w4wXUgyEMQmPxFJj7CfVHY10WOsScAX/rK6Soa15S1zXYadqH9TtlVreQ==",
       "dependencies": {
         "cids": "^1.0.0",
         "dns-over-http-resolver": "^1.0.0",
@@ -9030,23 +8960,18 @@
       }
     },
     "node_modules/multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.1.0.tgz",
+      "integrity": "sha512-f6d4DhbQ9a8WiJ/wpbKgeJSeR0/juP/1wnjbKdZ0KAWDkC/z7Lb3xOegMUG+uTcfwSYf6j1eTvFf8HDgqPRGmQ==",
       "dependencies": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
+        "uint8arrays": "^2.1.5",
+        "varint": "^6.0.0"
       }
     },
-    "node_modules/multicodec/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-    },
     "node_modules/multiformats": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.0.4.tgz",
-      "integrity": "sha512-QWGCSOO4aSEZO4fUCZC1tkvd6rtPTzkAT5AaEshWWJIwd544YTBrrJFmICTp/hEUiOhOyDBJuwnjsFQCTIKLeQ=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
+      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
     },
     "node_modules/multihashes": {
       "version": "4.0.2",
@@ -9238,9 +9163,9 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "node_modules/node-stream-zip": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.13.5.tgz",
-      "integrity": "sha512-Lfi9xhSNvnJU35+4ZFlECXKJ70etAgJYWAVCdcEpksPnMrgwNqwkCJqdunoViVoFFV38C7AIodYE+2apuoK9Gw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.13.6.tgz",
+      "integrity": "sha512-c7tRSVkLNOHvasWgmZ2d86cDgTWEygnkuuHNOY9c0mR3yLZtQTTrGvMaJ/fPs6+LOJn3240y30l5sjLaXFtcvw==",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -11143,6 +11068,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "deprecated": "some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added",
       "peer": true,
       "dependencies": {
         "@cnakazawa/watch": "^1.0.3",
@@ -13016,11 +12942,12 @@
       }
     },
     "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "peer": true,
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/unpipe": {
@@ -13387,9 +13314,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -13619,9 +13546,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.5.tgz",
-      "integrity": "sha512-kixrYn4JwfAVPa0f2yfzc2AWti6WRRyO3XjWW5PJAvtE11qhSayrrcrEnee05KAtNaPC+EwehE8Qt1UedEVB8w=="
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+      "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
     },
     "@babel/core": {
       "version": "7.14.6",
@@ -13783,9 +13710,9 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.5.tgz",
-      "integrity": "sha512-UxUeEYPrqH1Q/k0yRku1JE7dyfyehNwT6SVkMHvYvPDv4+uu627VXBckVj891BO8ruKBkiDoGnZf4qPDD8abDQ==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+      "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
       "requires": {
         "@babel/types": "^7.14.5"
       }
@@ -13968,9 +13895,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.6.tgz",
-      "integrity": "sha512-oG0ej7efjEXxb4UgE+klVx+3j4MVo+A2vCzm7OUN4CLo6WhQ+vSOD2yJ8m7B+DghObxtLxt3EfgMWpq+AsWehQ=="
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+      "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.14.5",
@@ -13984,9 +13911,9 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.5.tgz",
-      "integrity": "sha512-tbD/CG3l43FIXxmu4a7RBe4zH7MLJ+S/lFowPFO7HetS2hyOZ/0nnnznegDuzFzfkyQYTxqdTH/hKmuBngaDAA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.7.tgz",
+      "integrity": "sha512-RK8Wj7lXLY3bqei69/cc25gwS5puEc3dknoFPFbqfy3XxYQBQFvu4ioWpafMBAB+L9NyptQK4nMOa5Xz16og8Q==",
       "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5",
@@ -14086,12 +14013,12 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.5.tgz",
-      "integrity": "sha512-VzMyY6PWNPPT3pxc5hi9LloKNr4SSrVCg7Yr6aZpW4Ym07r7KqSU/QXYwjXLVxqwSv0t/XSXkFoKBPUkZ8vb2A==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.7.tgz",
+      "integrity": "sha512-082hsZz+sVabfmDWo1Oct1u1AgbKbUAyVgmX4otIc7bdsRgHBXwTwb3DpDmD4Eyyx6DNiuz5UAATT655k+kL5g==",
       "peer": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.14.7",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
@@ -14376,9 +14303,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.5.tgz",
-      "integrity": "sha512-wU9tYisEbRMxqDezKUqC9GleLycCRoUsai9ddlsq54r8QRLaeEhc+d+9DqCG+kV9W2GgQjTZESPTpn5bAFMDww==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
       "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -14507,9 +14434,9 @@
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.5.tgz",
-      "integrity": "sha512-+Xe5+6MWFo311U8SchgeX5c1+lJM+eZDBZgD+tvXu9VVQPXwwVzeManMMjYX6xw2HczngfOSZjoFYKwdeB/Jvw==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.7.tgz",
+      "integrity": "sha512-DTNOTaS7TkW97xsDMrp7nycUVh6sn/eq22VaxWfEdzuEbRsiaOU0pqU7DlyUGHVsbQbSghvjKRpEl+nUCKGQSg==",
       "peer": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.14.5"
@@ -14718,17 +14645,17 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.5.tgz",
-      "integrity": "sha512-ci6TsS0bjrdPpWGnQ+m4f+JSSzDKlckqKIJJt9UZ/+g7Zz9k0N8lYU8IeLg/01o2h8LyNZDMLGgRLDTxpudLsA==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.7.tgz",
+      "integrity": "sha512-itOGqCKLsSUl0Y+1nSfhbuuOlTs0MJk2Iv7iSH+XT/mR8U1zRLO7NjWlYXB47yhK4J/7j+HYty/EhFZDYKa/VA==",
       "peer": true,
       "requires": {
-        "@babel/compat-data": "^7.14.5",
+        "@babel/compat-data": "^7.14.7",
         "@babel/helper-compilation-targets": "^7.14.5",
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.14.5",
-        "@babel/plugin-proposal-async-generator-functions": "^7.14.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.14.7",
         "@babel/plugin-proposal-class-properties": "^7.14.5",
         "@babel/plugin-proposal-class-static-block": "^7.14.5",
         "@babel/plugin-proposal-dynamic-import": "^7.14.5",
@@ -14737,7 +14664,7 @@
         "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
         "@babel/plugin-proposal-numeric-separator": "^7.14.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
         "@babel/plugin-proposal-optional-chaining": "^7.14.5",
         "@babel/plugin-proposal-private-methods": "^7.14.5",
@@ -14763,7 +14690,7 @@
         "@babel/plugin-transform-block-scoping": "^7.14.5",
         "@babel/plugin-transform-classes": "^7.14.5",
         "@babel/plugin-transform-computed-properties": "^7.14.5",
-        "@babel/plugin-transform-destructuring": "^7.14.5",
+        "@babel/plugin-transform-destructuring": "^7.14.7",
         "@babel/plugin-transform-dotall-regex": "^7.14.5",
         "@babel/plugin-transform-duplicate-keys": "^7.14.5",
         "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
@@ -14775,7 +14702,7 @@
         "@babel/plugin-transform-modules-commonjs": "^7.14.5",
         "@babel/plugin-transform-modules-systemjs": "^7.14.5",
         "@babel/plugin-transform-modules-umd": "^7.14.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.5",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.7",
         "@babel/plugin-transform-new-target": "^7.14.5",
         "@babel/plugin-transform-object-super": "^7.14.5",
         "@babel/plugin-transform-parameters": "^7.14.5",
@@ -14783,7 +14710,7 @@
         "@babel/plugin-transform-regenerator": "^7.14.5",
         "@babel/plugin-transform-reserved-words": "^7.14.5",
         "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-        "@babel/plugin-transform-spread": "^7.14.5",
+        "@babel/plugin-transform-spread": "^7.14.6",
         "@babel/plugin-transform-sticky-regex": "^7.14.5",
         "@babel/plugin-transform-template-literals": "^7.14.5",
         "@babel/plugin-transform-typeof-symbol": "^7.14.5",
@@ -14794,7 +14721,7 @@
         "babel-plugin-polyfill-corejs2": "^0.2.2",
         "babel-plugin-polyfill-corejs3": "^0.2.2",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
-        "core-js-compat": "^3.14.0",
+        "core-js-compat": "^3.15.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -14955,16 +14882,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.5.tgz",
-      "integrity": "sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+      "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
       "requires": {
         "@babel/code-frame": "^7.14.5",
         "@babel/generator": "^7.14.5",
         "@babel/helper-function-name": "^7.14.5",
         "@babel/helper-hoist-variables": "^7.14.5",
         "@babel/helper-split-export-declaration": "^7.14.5",
-        "@babel/parser": "^7.14.5",
+        "@babel/parser": "^7.14.7",
         "@babel/types": "^7.14.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -14996,18 +14923,18 @@
       "peer": true
     },
     "@hapi/topo": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "peer": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
     },
     "@ipld/car": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.0.3.tgz",
-      "integrity": "sha512-c5/LmjjWFDicqcRvJNfhC394wt9ZUKDzzdzMZdrXI1xCBCCtimlKhVaIlxh2+9lFvV50alPBqGK+jhnjXPbmEQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.2.tgz",
+      "integrity": "sha512-BW1W9S7ol4I0OXx604XjvUABj9RLiNetOiJ3drdbGMvh6YgzCTnBDHPjvilB5tMs1yml2we2T6YHtgJvXg5osA==",
       "requires": {
         "@ipld/dag-cbor": "^6.0.0",
         "@types/varint": "^6.0.0",
@@ -15025,9 +14952,9 @@
       }
     },
     "@ipld/dag-pb": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.0.2.tgz",
-      "integrity": "sha512-m0XOtq2zx+F6FqPCrBh4tjTxyAzRE8IIjAPZsfXoXcqOC8HhOiH3nrvk3sXgLuU3Ttxkitkn5ntS4r8LX0ZDVA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.1.tgz",
+      "integrity": "sha512-bB7HxHlyKtLRbZVJQxdi+CakXFfQKogINzUxvhfGURUpZLvwTq3x8jwHT1UvPWuO0SHgMBQN5mIBeOUnes3MHg==",
       "requires": {
         "multiformats": "^9.0.0"
       }
@@ -15329,26 +15256,6 @@
             "path-exists": "^4.0.0"
           }
         },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -15521,12 +15428,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "peer": true
         }
       }
     },
@@ -15601,26 +15502,6 @@
             "supports-color": "^7.1.0"
           }
         },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15629,12 +15510,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "peer": true
         }
       }
     },
@@ -16023,6 +15898,11 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
+    "@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
+    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -16035,9 +15915,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.4.tgz",
-      "integrity": "sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA=="
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -16119,11 +15999,11 @@
       }
     },
     "@vascosantos/ipfs-unixfs-importer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.0.tgz",
-      "integrity": "sha512-6RlyqSbcSw3Uhkz9tmZdbBbSNLTFmb0/M5wqaxakqKcjLNXNZNX1cYJcszOzfQ2U6VM6hTlOlun/vGiJuVsUiQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@vascosantos/ipfs-unixfs-importer/-/ipfs-unixfs-importer-9.0.3.tgz",
+      "integrity": "sha512-kVcp+yZavn5Tn5EL7RHH51kSoO+gx1Yz22NtzmPFVNRx/cZ039VNZFI5XHkFT4FkFiskLv97nEzM/rOyug0wRw==",
       "requires": {
-        "@ipld/dag-pb": "^2.0.2",
+        "@ipld/dag-pb": "^2.1.1",
         "bl": "^5.0.0",
         "err-code": "^3.0.1",
         "hamt-sharding": "^2.0.0",
@@ -16133,11 +16013,11 @@
         "it-first": "^1.0.6",
         "it-parallel-batch": "^1.0.9",
         "merge-options": "^3.0.4",
-        "multicodec": "^3.0.1",
+        "multicodec": "^3.1.0",
         "multiformats": "^9.0.4",
         "multihashing-async": "^2.1.0",
         "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.2"
+        "uint8arrays": "^2.1.5"
       }
     },
     "@web-std/blob": {
@@ -16276,9 +16156,9 @@
       }
     },
     "appdirsjs": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.4.tgz",
-      "integrity": "sha512-WO5StDORR6JF/xYnXk/Fm0yu+iULaV5ULKuUw0Tu+jbgiTlSquaWBCgbpnsHLMXldf+fM3Gxn5p7vjond7He6w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/appdirsjs/-/appdirsjs-1.2.5.tgz",
+      "integrity": "sha512-UyaAyzj+7XLoKhbXJi4zoAw8IDXCiLNCKfQEiuCsCCTkDmiG1vpCliQn/MoUvO3DZqCN1i6gOahokcFtNSIrVA==",
       "peer": true
     },
     "append-transform": {
@@ -16420,11 +16300,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "peer": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -16591,9 +16466,9 @@
       }
     },
     "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
+      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "blob-to-it": {
       "version": "1.0.2",
@@ -16780,9 +16655,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001239",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ=="
+      "version": "1.0.30001241",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
+      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -17176,9 +17051,9 @@
       "peer": true
     },
     "core-js-compat": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.0.tgz",
-      "integrity": "sha512-8X6lWsG+s7IfOKzV93a7fRYfWRZobOfjw5V5rrq43Vh/W+V6qYxl7Akalsvgab4PFT/4L/pjQbdBUEM36NXKrw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.15.1.tgz",
+      "integrity": "sha512-xGhzYMX6y7oEGQGAJmP2TmtBLvR4nZmRGEcFa3ubHOq5YEp51gGN9AovVa0AoujGZIq+Wm6dISiYyGNfdflYww==",
       "peer": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -17484,9 +17359,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.752",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.752.tgz",
-      "integrity": "sha512-2Tg+7jSl3oPxgsBsWKh5H83QazTkmWG/cnNwJplmyZc7KcN61+I10oUgaXSVk/NwfvN3BdkKDR4FYuRBQQ2v0A=="
+      "version": "1.3.760",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.760.tgz",
+      "integrity": "sha512-XPKwjX6pHezJWB4FLVuSil9gGmU6XYl27ahUwEHODXF4KjCEB8RuIT05MkU1au2Tdye57o49yY0uCMK+bwUt+A=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -17942,17 +17817,16 @@
       "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fastq": {
@@ -18107,14 +17981,14 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "peer": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -19052,11 +18926,11 @@
       "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
     },
     "it-glob": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.11.tgz",
-      "integrity": "sha512-p02iVYsvOPU7cW4sV9BC62Kz6Mz2aUTJz/cKWDeFqc05kzB3WgSq8OobZabVA/K4boSm6q+s0xOZ8xiArLSoXQ==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
+      "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
       "requires": {
-        "fs-extra": "^9.0.1",
+        "@types/minimatch": "^3.0.4",
         "minimatch": "^3.0.4"
       }
     },
@@ -19432,12 +19306,12 @@
       }
     },
     "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "peer": true,
       "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -20556,9 +20430,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "multiaddr": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.1.tgz",
-      "integrity": "sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.2.tgz",
+      "integrity": "sha512-YFaEb9t4yXSbaGksSEdg+Kn2U02s7w4wXUgyEMQmPxFJj7CfVHY10WOsScAX/rK6Soa15S1zXYadqH9TtlVreQ==",
       "requires": {
         "cids": "^1.0.0",
         "dns-over-http-resolver": "^1.0.0",
@@ -20586,25 +20460,18 @@
       }
     },
     "multicodec": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
-      "integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.1.0.tgz",
+      "integrity": "sha512-f6d4DhbQ9a8WiJ/wpbKgeJSeR0/juP/1wnjbKdZ0KAWDkC/z7Lb3xOegMUG+uTcfwSYf6j1eTvFf8HDgqPRGmQ==",
       "requires": {
-        "uint8arrays": "^2.1.3",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-        }
+        "uint8arrays": "^2.1.5",
+        "varint": "^6.0.0"
       }
     },
     "multiformats": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.0.4.tgz",
-      "integrity": "sha512-QWGCSOO4aSEZO4fUCZC1tkvd6rtPTzkAT5AaEshWWJIwd544YTBrrJFmICTp/hEUiOhOyDBJuwnjsFQCTIKLeQ=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.1.0.tgz",
+      "integrity": "sha512-NhIM1NI9O2BSgWQWRsf8qEkRjKgNwEtwPb+gJKNMZW4xM/l1HbRktjXJvcG936QL/hrUh54T959JuLMF65Cbhw=="
     },
     "multihashes": {
       "version": "4.0.2",
@@ -20755,9 +20622,9 @@
       "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
     },
     "node-stream-zip": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.13.5.tgz",
-      "integrity": "sha512-Lfi9xhSNvnJU35+4ZFlECXKJ70etAgJYWAVCdcEpksPnMrgwNqwkCJqdunoViVoFFV38C7AIodYE+2apuoK9Gw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.13.6.tgz",
+      "integrity": "sha512-c7tRSVkLNOHvasWgmZ2d86cDgTWEygnkuuHNOY9c0mR3yLZtQTTrGvMaJ/fPs6+LOJn3240y30l5sjLaXFtcvw==",
       "peer": true
     },
     "normalize-package-data": {
@@ -23719,9 +23586,10 @@
       }
     },
     "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "peer": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -24022,9 +23890,9 @@
       }
     },
     "ws": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-      "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
       "requires": {}
     },
     "xcode": {

--- a/src/pack/blob.ts
+++ b/src/pack/blob.ts
@@ -1,13 +1,12 @@
 import { Blob } from "@web-std/blob"
 import all from 'it-all'
-import { ImportCandidateStream as ImportCandidateStreamT } from 'ipfs-core-types/src/utils'
+import type { ImportCandidateStream } from 'ipfs-core-types/src/utils'
+export type { ImportCandidateStream }
 
 import { Blockstore } from '../blockstore'
 import { MemoryBlockStore } from '../blockstore/memory'
 
 import { pack } from './index'
-
-export type ImportCandidateStream = ImportCandidateStreamT
 
 export async function packToBlob ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/pack/blob.ts
+++ b/src/pack/blob.ts
@@ -1,11 +1,13 @@
 import { Blob } from "@web-std/blob"
 import all from 'it-all'
-import { ImportCandidateStream } from 'ipfs-core-types/src/utils'
+import { ImportCandidateStream as ImportCandidateStreamT } from 'ipfs-core-types/src/utils'
 
 import { Blockstore } from '../blockstore'
 import { MemoryBlockStore } from '../blockstore/memory'
 
 import { pack } from './index'
+
+export type ImportCandidateStream = ImportCandidateStreamT
 
 export async function packToBlob ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -4,11 +4,13 @@ import pipe from 'it-pipe'
 import { CarWriter } from '@ipld/car'
 import { importer } from '@vascosantos/ipfs-unixfs-importer'
 import normalizeAddInput from 'ipfs-core-utils/src/files/normalise-input/index.js'
-import { ImportCandidateStream } from 'ipfs-core-types/src/utils'
+import { ImportCandidateStream as ImportCandidateStreamT } from 'ipfs-core-types/src/utils'
 import { sha256 } from 'multiformats/hashes/sha2'
 
 import { Blockstore } from '../blockstore/index'
 import { MemoryBlockStore } from '../blockstore/memory'
+
+export type ImportCandidateStream = ImportCandidateStreamT
 
 export async function pack ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/pack/index.ts
+++ b/src/pack/index.ts
@@ -4,13 +4,12 @@ import pipe from 'it-pipe'
 import { CarWriter } from '@ipld/car'
 import { importer } from '@vascosantos/ipfs-unixfs-importer'
 import normalizeAddInput from 'ipfs-core-utils/src/files/normalise-input/index.js'
-import { ImportCandidateStream as ImportCandidateStreamT } from 'ipfs-core-types/src/utils'
+import type { ImportCandidateStream } from 'ipfs-core-types/src/utils'
+export type { ImportCandidateStream }
 import { sha256 } from 'multiformats/hashes/sha2'
 
 import { Blockstore } from '../blockstore/index'
 import { MemoryBlockStore } from '../blockstore/memory'
-
-export type ImportCandidateStream = ImportCandidateStreamT
 
 export async function pack ({ input, blockstore: userBlockstore }: { input: ImportCandidateStream, blockstore?: Blockstore }) {
   const blockstore = userBlockstore ? userBlockstore : new MemoryBlockStore()

--- a/src/unpack/index.ts
+++ b/src/unpack/index.ts
@@ -5,9 +5,8 @@ import { CarIndexedReader, CarReader } from '@ipld/car'
 import { Block } from '@ipld/car/api'
 import { CID } from 'multiformats'
 import exporter from '@vascosantos/ipfs-unixfs-exporter'
-import { UnixFSEntry as UnixFSEntryT } from '@vascosantos/ipfs-unixfs-exporter'
-
-export type UnixFSEntry = UnixFSEntryT
+import type { UnixFSEntry } from '@vascosantos/ipfs-unixfs-exporter'
+export type { UnixFSEntry }
 
 // Export unixfs entries from car file
 export async function* unpack(carReader: CarReader | CarIndexedReader, roots?: CID[]): AsyncIterable<UnixFSEntry> {

--- a/src/unpack/index.ts
+++ b/src/unpack/index.ts
@@ -1,7 +1,7 @@
 import equals from 'uint8arrays/equals'
 import { sha256 } from 'multiformats/hashes/sha2'
 
-import { CarIndexedReader, CarReader } from '@ipld/car'
+import { CarReader } from '@ipld/car/api'
 import { Block } from '@ipld/car/api'
 import { CID } from 'multiformats'
 import exporter from '@vascosantos/ipfs-unixfs-exporter'
@@ -9,7 +9,7 @@ import type { UnixFSEntry } from '@vascosantos/ipfs-unixfs-exporter'
 export type { UnixFSEntry }
 
 // Export unixfs entries from car file
-export async function* unpack(carReader: CarReader | CarIndexedReader, roots?: CID[]): AsyncIterable<UnixFSEntry> {
+export async function* unpack(carReader: CarReader, roots?: CID[]): AsyncIterable<UnixFSEntry> {
   const verifyingBlockService = {
     get: async (cid: CID) => {
       const res = await carReader.get(cid)

--- a/src/unpack/index.ts
+++ b/src/unpack/index.ts
@@ -5,10 +5,12 @@ import { CarIndexedReader, CarReader } from '@ipld/car'
 import { Block } from '@ipld/car/api'
 import { CID } from 'multiformats'
 import exporter from '@vascosantos/ipfs-unixfs-exporter'
-import { UnixFSEntry } from '@vascosantos/ipfs-unixfs-exporter'
+import { UnixFSEntry as UnixFSEntryT } from '@vascosantos/ipfs-unixfs-exporter'
+
+export type UnixFSEntry = UnixFSEntryT
 
 // Export unixfs entries from car file
-export async function* unpack (carReader: CarReader|CarIndexedReader, roots?: CID[]): AsyncIterable<UnixFSEntry> {
+export async function* unpack(carReader: CarReader | CarIndexedReader, roots?: CID[]): AsyncIterable<UnixFSEntry> {
   const verifyingBlockService = {
     get: async (cid: CID) => {
       const res = await carReader.get(cid)


### PR DESCRIPTION
This PR exports external types so that consumers do not have to import modules like unixfs to access them

Package lock was also updated
