### PR TITLE
fix: do not use uint8array default export

### DIFF
--- a/src/unpack/index.ts
+++ b/src/unpack/index.ts
@@ -1,4 +1,4 @@
-import equals from 'uint8arrays/equals'
+import { equals } from 'uint8arrays'
 import { sha256 } from 'multiformats/hashes/sha2'
 
 import { CarReader } from '@ipld/car/api'


### PR DESCRIPTION
When trying to use `unpack` with esm we get the following error

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/oli/Code/filecoin-storage/filecoin.storage/packages/client/node_modules/uint8arrays/equals' imported from /Users/oli/Code/filecoin-storage/filecoin.storage/packages/client/node_modules/ipfs-car/dist/esm/unpack/index.js
Did you mean to import uint8arrays/equals.js?

The generated code previously was

```js
import equals from 'uint8arrays/equals';
```

and now is

```js
import { equals } from 'uint8arrays';
```

This is likely related to `uint8arrays/equals` exporting default and/or `uint8arrays` do not have exports property in [package.json](https://github.com/achingbrain/uint8arrays/blob/master/package.json).